### PR TITLE
Added selectors and variables

### DIFF
--- a/main.css
+++ b/main.css
@@ -61,6 +61,12 @@ body .multiple-windows__document,
   border-radius: var(--highlight-border-radius, 0px);
 }
 
+/* gutter (page seperation) */
+.gutter.gutter-horizontal {
+  background-color:var(--gutter-color);
+  
+}
+
 /* Body Text */
 .multiple-windows__document,
 .rem-text,
@@ -85,6 +91,19 @@ body .multiple-windows__document,
 .rem-reference-link {
   color: var(--text-rem-color, #0231bf);
 }
+
+/* Rem Bullet */
+.rem-bullet,.rem-bullet--in-list {
+  background-color:var(--rem-bullet-color,rgb(75,75,75));
+}
+
+/* Tree Lines */
+#hierarchy-editor .TreeNode {
+  border-left-color: var(--tree-line-color);
+  border-left-width: var(--tree-line-width);
+  border-left-style: var(--tree-line-style);
+}
+
 /* Header Text */
 /* .rem-header,
 .rem-header--1,


### PR DESCRIPTION
- Rem Bullet Color
- Tree Lines
- Gutter Color (Split pane seperator)

I didn't update the install.md file with the new variables because I'm not sure how it should be formatted. Is there a reason the different categories are a bullet list in markdown instead of included in the code snippet as comments to seperate the categories? that way people can copy the entire thing directly into a RemNote codeblock. Apologize if I misunderstand the intent.